### PR TITLE
Add global variable argument

### DIFF
--- a/LessMsbuildTasks/NodelessCompile.cs
+++ b/LessMsbuildTasks/NodelessCompile.cs
@@ -71,6 +71,11 @@ namespace LessMsbuildTasks
         /// </summary>
         public bool LessDisableUrlRewriting { get; set; }
 
+		/// <summary>
+		/// Set a global variable for the less compilation
+		/// </summary>
+		public string LessGlobalVar { get; set; }
+
 
         /// <summary>
         /// Maintain a list of processed files so we don't process them again.
@@ -189,6 +194,10 @@ namespace LessMsbuildTasks
 
             //Add output file
             args.Add( Quote(outputFilePath) );
+
+			if ( this.LessGlobalVar != string.Empty ) {
+				args.Add( "--global-var=\"" + this.LessGlobalVar + "\"" );
+			}
 
             return String.Join( " ", args );
 

--- a/LessMsbuildTasks/NodelessCompile.cs
+++ b/LessMsbuildTasks/NodelessCompile.cs
@@ -72,10 +72,16 @@ namespace LessMsbuildTasks
         public bool LessDisableUrlRewriting { get; set; }
 
 		/// <summary>
-		/// Set a global variable for the less compilation
+		/// Set global variables for the less compilation defined in an item group array
+		/// Format for each item "my-var=value"
 		/// </summary>
-		public string LessGlobalVar { get; set; }
+		public string[] LessGlobalVars { get; set; }
 
+		/// <summary>
+		/// Modify variables for the less compilation defined in an item group array
+		/// Format for each item "my-var=value"
+		/// </summary>
+		public string[] LessModifyVars { get; set; }
 
         /// <summary>
         /// Maintain a list of processed files so we don't process them again.
@@ -195,8 +201,16 @@ namespace LessMsbuildTasks
             //Add output file
             args.Add( Quote(outputFilePath) );
 
-			if ( this.LessGlobalVar != string.Empty ) {
-				args.Add( "--global-var=\"" + this.LessGlobalVar + "\"" );
+			if ( this.LessGlobalVars != null ) {
+				foreach ( var globalVar in this.LessGlobalVars ) {
+					args.Add( "--global-var=\"" + globalVar + "\"" );
+				}
+			}
+
+			if ( this.LessModifyVars != null ) {
+				foreach ( var modVar in this.LessModifyVars ) {
+					args.Add( "--modify-var=\"" + modVar + "\"" );
+				}
 			}
 
             return String.Join( " ", args );


### PR DESCRIPTION
Add an argument to to allow setting of the compiler --global-var option.
This allows the definition of a global variable for the less compilation.