### PR TITLE
Add lessc error message parsing

### DIFF
--- a/LessMsbuildTasks/NodelessCompile.cs
+++ b/LessMsbuildTasks/NodelessCompile.cs
@@ -259,7 +259,18 @@ namespace LessMsbuildTasks
                 if (!_Errors.Contains( errorStr ))
                 {
                     result = false;
-                    Log.LogError( errorStr );
+                    try
+                    {
+                        var groups = Regex.Match(errorStr, @"(\w+):.*?on line (\d+), column (\d+):").Groups;
+                        var errorClass = groups[1].Value;
+                        var line = Int32.Parse(groups[2].Value);
+                        var column = Int32.Parse(groups[3].Value);
+                        Log.LogError("CompileLessFile", "", errorClass, inputFilePath, line, column, line, column, errorStr);
+                    }
+                    catch
+                    {
+                        Log.LogError(errorStr);
+                    }
                     _Errors.Add( errorStr );
                 }
             }


### PR DESCRIPTION
Tries to find the line and the column in `*.less` file where error has occurred and shows it in Visual Studio's Error List.

Currently Error List points to `LessCompiler.targets` file for any `*.less` errors.