### PR TITLE
Remove space that results in compiler error

### DIFF
--- a/nugetBuild/LessCompiler.targets
+++ b/nugetBuild/LessCompiler.targets
@@ -19,7 +19,7 @@
     <LessVerbose Condition="$(LessVerbose) == ''">False</LessVerbose>
     <LessImportAllFilesAsLess Condition="$(LessImportAllFilesAsLess) == ''">False</LessImportAllFilesAsLess>
     <LessKeepRelativeDirectory Condition="$(LessKeepRelativeDirectory) == ''">True</LessKeepRelativeDirectory>
-    <LessDisableUrlRewriting  Condition ="$(LessDisableUrlRewriting ) == ''">False</LessDisableUrlRewriting >
+    <LessDisableUrlRewriting  Condition ="$(LessDisableUrlRewriting) == ''">False</LessDisableUrlRewriting >
     <LessPath Condition="$(LessVerbose) == ''"></LessPath>
     <LessOutputExtension Condition="'$(LessOutputExtension)' == ''">.css</LessOutputExtension>
     <OnAfter_CopyWebApplication>


### PR DESCRIPTION
Related to Issue #10 

This space causes the compiler to not load the project. 

```
Error: Unexpected space at position "25" of condition "$(LessDisableUrlRewriting )" == ''
```

![image](https://user-images.githubusercontent.com/385693/113695043-b8a33600-96d0-11eb-8c1e-cd7b36dad31e.png)
